### PR TITLE
Add option to specify scrollable element

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -18,6 +18,7 @@ export default Ember.Component.extend({
     this.set('guid', Ember.guidFor(this));
     this._bindScroll();
     this._checkIfInView();
+    this._checkScrollable();
   },
 
   willDestroyElement: function() {
@@ -43,6 +44,20 @@ export default Ember.Component.extend({
 
     if (inView && !this.get('developmentMode')) {
       this.sendAction('loadMoreAction');
+    }
+  },
+
+  _checkScrollable: function() {
+    var scrollable = this.get('scrollable');
+    if (Ember.$.type(scrollable) === 'string') {
+      var items = Ember.$(scrollable);
+      if (items.length === 1) {
+        this.set('scrollable', items[0]);
+      } else if (items.length > 1) {
+        throw new Error("Multiple scrollable elements found for: " + scrollable);
+      } else {
+        throw new Error("No scrollable element found for: " + scrollable);
+      }
     }
   },
 

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -12,13 +12,13 @@ export default Ember.Component.extend({
   loadedText: 'Infinite Model Entirely Loaded.',
   destroyOnInfinity: false,
   developmentMode: false,
-  scrollable: window,
+  scrollable: null,
 
   didInsertElement: function() {
+    this._setupScrollable();
     this.set('guid', Ember.guidFor(this));
     this._bindScroll();
     this._checkIfInView();
-    this._checkScrollable();
   },
 
   willDestroyElement: function() {
@@ -27,18 +27,19 @@ export default Ember.Component.extend({
 
   _bindScroll: function() {
     var _this = this;
-    Ember.$(this.get("scrollable")).on("scroll."+this.get('guid'), function() {
+    this.get("scrollable").on("scroll."+this.get('guid'), function() {
       Ember.run.debounce(_this, _this._checkIfInView, _this.get('scrollDebounce'));
     });
   },
 
   _unbindScroll: function() {
-    Ember.$(this.get("scrollable")).off("scroll."+this.get('guid'));
+    this.get("scrollable").off("scroll."+this.get('guid'));
   },
 
   _checkIfInView: function() {
-    var selfOffset   = this.$().offset().top;
-    var scrollableBottom = Ember.$(this.get("scrollable")).height() + Ember.$(this.get("scrollable")).scrollTop();
+    var selfOffset       = this.$().offset().top;
+    var scrollable       = this.get("scrollable");
+    var scrollableBottom = scrollable.height() + scrollable.scrollTop();
 
     var inView = selfOffset < scrollableBottom ? true : false;
 
@@ -47,17 +48,19 @@ export default Ember.Component.extend({
     }
   },
 
-  _checkScrollable: function() {
+  _setupScrollable: function() {
     var scrollable = this.get('scrollable');
     if (Ember.$.type(scrollable) === 'string') {
       var items = Ember.$(scrollable);
       if (items.length === 1) {
-        this.set('scrollable', items[0]);
+        this.set('scrollable', items.eq(0));
       } else if (items.length > 1) {
         throw new Error("Multiple scrollable elements found for: " + scrollable);
       } else {
         throw new Error("No scrollable element found for: " + scrollable);
       }
+    } else {
+      this.set('scrollable', Ember.$(window));
     }
   },
 

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -12,6 +12,7 @@ export default Ember.Component.extend({
   loadedText: 'Infinite Model Entirely Loaded.',
   destroyOnInfinity: false,
   developmentMode: false,
+  scrollable: window,
 
   didInsertElement: function() {
     this.set('guid', Ember.guidFor(this));
@@ -25,20 +26,20 @@ export default Ember.Component.extend({
 
   _bindScroll: function() {
     var _this = this;
-    Ember.$(window).on("scroll."+this.get('guid'), function() {
+    Ember.$(this.get("scrollable")).on("scroll."+this.get('guid'), function() {
       Ember.run.debounce(_this, _this._checkIfInView, _this.get('scrollDebounce'));
     });
   },
 
   _unbindScroll: function() {
-    Ember.$(window).off("scroll."+this.get('guid'));
+    Ember.$(this.get("scrollable")).off("scroll."+this.get('guid'));
   },
 
   _checkIfInView: function() {
     var selfOffset   = this.$().offset().top;
-    var windowBottom = Ember.$(window).height() + Ember.$(window).scrollTop();
+    var scrollableBottom = Ember.$(this.get("scrollable")).height() + Ember.$(this.get("scrollable")).scrollTop();
 
-    var inView = selfOffset < windowBottom ? true : false;
+    var inView = selfOffset < scrollableBottom ? true : false;
 
     if (inView && !this.get('developmentMode')) {
       this.sendAction('loadMoreAction');

--- a/tests/unit/components/infinity-loader-test.js
+++ b/tests/unit/components/infinity-loader-test.js
@@ -68,3 +68,36 @@ test('it changes text property', function(assert) {
   assert.equal(componentText, "Infinite Model Entirely Loaded.");
 });
 
+test('it uses the window as the scrollable element', function(assert) {
+  assert.expect(1);
+  var component = this.subject();
+  this.render();
+  var scrollable = component.get("scrollable");
+  assert.equal(scrollable, window);
+});
+
+test('it uses the provided scrollable element', function(assert) {
+  assert.expect(1);
+  $(document.body).append("<div id='content'/>");
+  var component = this.subject({scrollable: "#content"});
+  this.render();
+  var scrollable = component.get("scrollable");
+  assert.equal(scrollable, $("#content")[0]);
+});
+
+test('it throws error when scrollable element is not found', function(assert) {
+  assert.expect(1);
+  var component = this.subject({scrollable: "#notfound"});
+  assert.throws(function() {
+    this.render();
+  }, Error, "Should raise error");
+});
+
+test('it throws error when multiple scrollable elements are found', function(assert) {
+  assert.expect(1);
+  $(document.body).append("<div/><div/>");
+  var component = this.subject({scrollable: "div"});
+  assert.throws(function() {
+    this.render();
+  }, Error, "Should raise error");
+});

--- a/tests/unit/components/infinity-loader-test.js
+++ b/tests/unit/components/infinity-loader-test.js
@@ -73,7 +73,7 @@ test('it uses the window as the scrollable element', function(assert) {
   var component = this.subject();
   this.render();
   var scrollable = component.get("scrollable");
-  assert.equal(scrollable, window);
+  assert.equal(scrollable[0], window);
 });
 
 test('it uses the provided scrollable element', function(assert) {
@@ -82,7 +82,7 @@ test('it uses the provided scrollable element', function(assert) {
   var component = this.subject({scrollable: "#content"});
   this.render();
   var scrollable = component.get("scrollable");
-  assert.equal(scrollable, $("#content")[0]);
+  assert.equal(scrollable[0], $("#content")[0]);
 });
 
 test('it throws error when scrollable element is not found', function(assert) {


### PR DESCRIPTION
The scrollable defaults to `window` if the option is not used.
Usage:

```
<div id="content">
{{#each model as |product|}}
  <h1>{{product.name}}</h1>
  <h2>{{product.description}}</h1>
{{/each}}
</div>
{{infinity-loader infinityModel=model scrollable="#content"}}
```