### PR TITLE
Add descriptive error message when running ember-cli < 0.2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,12 @@
 /* jshint node: true */
 'use strict';
 
+var checker = require('ember-cli-version-checker');
+
 module.exports = {
-  name: 'ember-infinity'
+  name: 'ember-infinity',
+
+  init: function() {
+    checker.assertAbove(this, '0.2.0');
+  }
 };

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "ember-cli-pretender": "0.3.1",
     "ember-cli-qunit": "0.3.9",
     "ember-cli-uglify": "1.0.1",
+    "ember-cli-version-checker": "^1.0.2",
     "ember-data": "1.0.0-beta.15",
     "ember-export-application-global": "^1.0.2"
   },


### PR DESCRIPTION
Was getting an ambiguous error `Missing template processor` when trying to boot my server after installing this add-on and had a hard time figuring out why. Turns out I'm using ember-cli 0.1.15 and need to upgrade.