### PR TITLE
Fixes install command for new ember-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ repo, but without using controllers, in preparation for Ember 2.0.
 
 ## Installation
 
-`ember install:addon ember-infinity`
+`ember install ember-infinity`
 
 ## Basic Usage
 


### PR DESCRIPTION
Command for addon installation is now without addon keyword.
``` #3598 [ENHANCEMENT] Replace install:addon with install, remove install:bower and install:npm @DanielOchoa ```