### PR TITLE
Allow customization of pagination API

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,6 +18,7 @@ indent_style = space
 indent_size = 2
 
 [*.hbs]
+insert_final_newline = false
 indent_style = space
 indent_size = 2
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,7 @@
 bower_components/
 tests/
+tmp/
+dist/
 
 .bowerrc
 .editorconfig

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
 
 before_install:
   - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 ---
 language: node_js
+node_js:
+  - "0.12"
 
 sudo: false
 
@@ -7,7 +9,19 @@ cache:
   directories:
     - node_modules
 
+env:
+  - EMBER_TRY_SCENARIO=default
+  - EMBER_TRY_SCENARIO=ember-1.10
+  - EMBER_TRY_SCENARIO=ember-1.11
+  - EMBER_TRY_SCENARIO=ember-release
+  - EMBER_TRY_SCENARIO=ember-beta
+  - EMBER_TRY_SCENARIO=ember-canary
+
+matrix:
+  fast_finish: true
+
 before_install:
+  - export PATH=/usr/local/phantomjs-2.0.0/bin:$PATH
   - "npm config set spin false"
   - "npm install -g npm@^2"
 
@@ -17,4 +31,4 @@ install:
   - bower install
 
 script:
-  - npm test
+  - ember try $EMBER_TRY_SCENARIO test

--- a/README.md
+++ b/README.md
@@ -43,18 +43,67 @@ Now, whenever the `infinity-loader` is in view, it will send an action to the ro
 
 When the new records are loaded, they will automatically be pushed into the Model array.
 
-#### JSON Response
+## Advanced Usage
 
-The response provided by your server should include the number of total pages.
+### JSON Request/Response Customization
 
-```json
-  { "meta": { "total_pages": 4 } }
+By default, ember-infinity will send pagination parameters as part of a GET request as follows
+
+````
+/items?per_page=5&page=1
+```` 
+
+and will expect to recieve metadata in the response payload via a `total_pages` param in a `meta` object
+
+```js
+{
+  items: [
+    {id: 1, name: 'Test'},
+    {id: 2, name: 'Test 2'}
+  ],
+  meta: {
+    total_pages: 3
+  }
+}
 ```
 
-If your query returns 20 objects, and you're showing 6 per page, then the
-number of total pages would be 4.
+If you wish to customize some aspects of the JSON contract for pagination, you may do so via your routes. For example: 
 
-## Advanced Usage
+```js
+import Ember from 'ember';
+import InfinityRoute from "ember-infinity/mixins/route";
+
+export default Ember.Route.extend(InfinityRoute, {
+  
+  perPageParam: "per",              // instead of "per_page"
+  pageParam: "pg",                  // instead of "page"
+  totalPagesParam: "meta.total",    // instead of "meta.total_pages"
+
+  model() {
+    /* Load pages of the Product Model, starting from page 1, in groups of 12. */
+    return this.infinityModel("product", { perPage: 12, startingPage: 1 });
+  }
+});
+```
+
+This will result in request query params being sent out as follows
+
+````
+/items?per=5&pg=1
+```` 
+
+and ember-infinity will be set up to parse the total number of pages from a JSON response like this:
+
+```js
+{
+  items: [
+    ...
+  ],
+  meta: {
+    total: 3
+  }
+}
+```
 
 ### infinityModel
 

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -92,7 +92,7 @@ export default Ember.Mixin.create({
   infinityModel: function(modelName, options) {
     var _this = this;
 
-    if (this.store === undefined){
+    if (Ember.isEmpty(this.store) || Ember.isEmpty(this.store.find)){
       throw new Ember.Error("Ember Data store is not available to infinityModel");
     } else if (modelName === undefined) {
       throw new Ember.Error("You must pass a Model Name to infinityModel");

--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,17 @@
 {
   "name": "ember-infinity",
   "dependencies": {
-    "jquery": "^1.11.1",
     "ember": "1.10.0",
-    "ember-data": "1.0.0-beta.15",
-    "ember-resolver": "~0.1.12",
-    "loader.js": "ember-cli/loader.js#3.2.0",
     "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.0.2",
-    "ember-qunit": "0.2.8",
+    "ember-data": "1.0.0-beta.17",
+    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.4",
+    "ember-qunit": "0.3.3",
     "ember-qunit-notifications": "0.0.7",
-    "qunit": "~1.17.1",
-    "pretender": "0.1.0"
+    "ember-resolver": "~0.1.15",
+    "jquery": "^1.11.1",
+    "loader.js": "ember-cli/loader.js#3.2.0",
+    "pretender": "0.6.0",
+    "qunit": "~1.17.1"
   }
 }

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -1,0 +1,47 @@
+module.exports = {
+  scenarios: [
+    {
+      name: 'default',
+      dependencies: {}
+    },
+    {
+      name: 'ember-1.10',
+      dependencies: {
+        'ember': '~1.10.0'
+      }
+    },
+    {
+      name: 'ember-1.11',
+      dependencies: {
+        'ember': '~1.11.3'
+      }
+    },
+    {
+      name: 'ember-release',
+      dependencies: {
+        'ember': 'components/ember#release'
+      },
+      resolutions: {
+        'ember': 'release'
+      }
+    },
+    {
+      name: 'ember-beta',
+      dependencies: {
+        'ember': 'components/ember#beta'
+      },
+      resolutions: {
+        'ember': 'beta'
+      }
+    },
+    {
+      name: 'ember-canary',
+      dependencies: {
+        'ember': 'components/ember#canary'
+      },
+      resolutions: {
+        'ember': 'canary'
+      }
+    }
+  ]
+};

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "scripts": {
     "start": "ember server",
     "build": "ember build",
-    "test": "ember test"
+    "test": "ember try:testall"
   },
   "repository": "https://github.com/hhff/ember-infinity",
   "engines": {
@@ -17,28 +17,31 @@
   },
   "author": "Hugh Francis",
   "license": "MIT",
-  "dependencies": {
-    "ember-cli-htmlbars": "0.7.4",
-    "ember-cli-version-checker": "^1.0.2"
-  },
   "devDependencies": {
-    "broccoli-asset-rev": "^2.0.0",
-    "ember-cli": "0.2.0",
-    "ember-cli-app-version": "0.3.2",
-    "ember-cli-babel": "^4.0.0",
-    "ember-cli-content-security-policy": "0.3.0",
-    "ember-cli-dependency-checker": "0.0.8",
+    "broccoli-asset-rev": "^2.0.2",
+    "ember-cli": "0.2.5",
+    "ember-cli-app-version": "0.3.3",
+    "ember-cli-content-security-policy": "0.4.0",
+    "ember-cli-dependency-checker": "^1.0.0",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
-    "ember-cli-pretender": "0.3.1",
-    "ember-cli-qunit": "0.3.9",
-    "ember-cli-uglify": "1.0.1",
-    "ember-data": "1.0.0-beta.15",
-    "ember-export-application-global": "^1.0.2"
+    "ember-cli-pretender": "0.3.2",
+    "ember-cli-qunit": "0.3.13",
+    "ember-cli-version-checker": "^1.0.2",
+    "ember-cli-uglify": "^1.0.1",
+    "ember-data": "1.0.0-beta.17",
+    "ember-disable-proxy-controllers": "^0.7.0",
+    "ember-export-application-global": "^1.0.2",
+    "ember-disable-prototype-extensions": "^1.0.0",
+    "ember-try": "0.0.5"
   },
   "keywords": [
     "ember-addon"
   ],
+  "dependencies": {
+    "ember-cli-babel": "^5.0.0",
+    "ember-cli-htmlbars": "0.7.6"
+  },
   "ember-addon": {
     "configPath": "tests/dummy/config"
   }

--- a/testem.json
+++ b/testem.json
@@ -1,6 +1,7 @@
 {
   "framework": "qunit",
   "test_page": "tests/index.html?hidepassed",
+  "disable_watching": true,
   "launch_in_ci": [
     "PhantomJS"
   ],

--- a/tests/acceptance/infinity-route-with-meta-test.js
+++ b/tests/acceptance/infinity-route-with-meta-test.js
@@ -28,8 +28,8 @@ module('Acceptance: Infinity Route', {
         } else {
           subset = posts;
         }
-        perPage = parseInt(request.queryParams.per_page);
-        startPage = parseInt(request.queryParams.page);
+        perPage = parseInt(request.queryParams.per_page, 10);
+        startPage = parseInt(request.queryParams.page, 10);
 
         var pageCount = Math.ceil(subset.length / perPage);
         offset = perPage * (startPage - 1);
@@ -69,9 +69,9 @@ test('it works with parameters', function(assert) {
     var postList       = find('ul');
     var infinityLoader = find('.infinity-loader');
 
-    assert.equal(postsTitle.text(), "Listing Posts using Parameters");
-    assert.equal(postList.find('li').length, 2);
-    assert.equal(postList.find('li:first-child').text(), "Squarepusher");
-    assert.equal(infinityLoader.hasClass('reached-infinity'), false);
+    assert.equal(postsTitle.text(), "Listing Posts using Parameters", "Post title text is correct");
+    assert.equal(postList.find('li').length, 2, "Two items should be in the list");
+    assert.equal(postList.find('li:first-child').text(), "Squarepusher", "First item should be 'Squarepusher'");
+    assert.equal(infinityLoader.hasClass('reached-infinity'), false, "Infinity should not yet have been reached");
   });
 });

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -1,0 +1,3 @@
+ul li {
+  height: 500px;
+}

--- a/tests/dummy/public/crossdomain.xml
+++ b/tests/dummy/public/crossdomain.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0"?>
 <!DOCTYPE cross-domain-policy SYSTEM "http://www.adobe.com/xml/dtds/cross-domain-policy.dtd">
 <cross-domain-policy>
-    <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
+  <!-- Read this: www.adobe.com/devnet/articles/crossdomain_policy_file_spec.html -->
 
-    <!-- Most restrictive policy: -->
-    <site-control permitted-cross-domain-policies="none"/>
+  <!-- Most restrictive policy: -->
+  <site-control permitted-cross-domain-policies="none"/>
 
-    <!-- Least restrictive policy: -->
-    <!--
-    <site-control permitted-cross-domain-policies="all"/>
-    <allow-access-from domain="*" to-ports="*" secure="false"/>
-    <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
-    -->
+  <!-- Least restrictive policy: -->
+  <!--
+  <site-control permitted-cross-domain-policies="all"/>
+  <allow-access-from domain="*" to-ports="*" secure="false"/>
+  <allow-http-request-headers-from domain="*" headers="*" secure="false"/>
+  -->
 </cross-domain-policy>

--- a/tests/dummy/public/robots.txt
+++ b/tests/dummy/public/robots.txt
@@ -1,2 +1,3 @@
 # http://www.robotstxt.org
 User-agent: *
+Disallow:

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -36,7 +36,9 @@ test('it can not use infinityModel without a Model Name', function(assert) {
     }
   });
   var route = RouteObject.create();
-  route.store = {};
+  route.store = {
+    find() {}
+  };
 
   var infinityError;
   try {


### PR DESCRIPTION
### Please merge #20 first

Currently this addon has the following request payload structure hardcoded

```js
{
  per_page: 10,
  page: 14
}
```
This PR allows customization of these two parameters, so that you could work with an API that expects to recieve something like
```js
{
  per: 10,
  p: 14
}
```