### PR TITLE
adds json response to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,17 @@ Now, whenever the `infinity-loader` is in view, it will send an action to the ro
 
 When the new records are loaded, they will automatically be pushed into the Model array.
 
+#### JSON Response
+
+The response provided by your server should include the number of total pages.
+
+```json
+  { "meta": { "total_pages": 4 } }
+```
+
+If your query returns 20 objects, and you're showing 6 per page, then the
+number of total pages would be 4.
+
 ## Advanced Usage
 
 ### infinityModel


### PR DESCRIPTION
wasn't clear from the documentation that the server needed to include
the number of total pages in the response

https://github.com/hhff/ember-infinity/issues/12

I left the example data incomplete, since it would depend on each application.

Thanks!