### PR TITLE
Update ember-cli-github-pages & Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![npm version](https://badge.fury.io/js/ember-infinity.svg)](http://badge.fury.io/js/ember-infinity)
 [![Ember Observer Score](http://emberobserver.com/badges/ember-infinity.svg)](http://emberobserver.com/addons/ember-infinity)
 
+Demo: [hhff.github.io/ember-infinity/](http://hhff.github.io/ember-infinity/)
+
 Simple, flexible infinite scrolling for Ember CLI Apps.  Works out of the box
 with the [Kaminari Gem](https://github.com/amatsuda/kaminari.git).
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "ember-cli-app-version": "0.3.3",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "^1.0.0",
-    "ember-cli-github-pages": "~0.0.4",
+    "ember-cli-github-pages": "poetic/ember-cli-github-pages#v0.0.5",
     "ember-cli-ic-ajax": "0.1.1",
     "ember-cli-inject-live-reload": "^1.3.0",
     "ember-cli-pretender": "0.3.2",


### PR DESCRIPTION
Demo app is now deployed to

http://hhff.github.io/ember-infinity/

I have added a link to the readme, and update ember-cli-github-pages to the newly tagged `v0.0.5` release