### PR TITLE
Added the ability to pass in extra params that are (computed) properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ actions: {
 
 ### infinityModel
 
-You can also provide additional parameters to `infinityModel` that
+You can also provide additional static parameters to `infinityModel` that
 will be passed to your backend server in addition to the
 pagination params. For instance, in the following example a `category`
 parameter is added:
@@ -134,6 +134,42 @@ parameter is added:
 ```js
 return this.infinityModel("product", { perPage: 12, startingPage: 1,
                                        category: "furniture" });
+```
+
+Moreover, you can optionally pass in an object of bound parameters as a third option to `infinityModel` to further 
+customize the request to the backend. The values of the contained parameters will be looked up against the route 
+properties and the respective values will be included in the request:
+
+```js
+import Ember from 'ember';
+import InfinityRoute from 'ember-infinity/mixins/route';
+
+export default Ember.Route.extend(InfinityRoute, {
+  ...
+
+  prod: function () { return this.get('cat'); }.property('cat'),
+  country: '',
+  cat: 'shipped',
+
+  model: function () {
+    return this.infinityModel("product", { perPage: 12, startingPage: 1, make: "original" }, { country: "country", category: "prod" });
+  }
+});
+```
+
+In the example above, the query url should look like this:
+
+```js
+    product?make=original&country=&category=shipped&per_page=12&page=1
+```
+
+If the value of the bound parameter cannot be found, the parameter is not included in the request. Note that you cannot have
+a static and bound parameter of the same name, the latter will take precedence.
+
+When you need to pass in bound parameters but no static parameters or custom pagination, call `infinityModel` with an empty object for it's second param:
+
+```js
+  return this.infinityModel("product", {}, { country: "country", category: "prod" });
 ```
 
 * **modelPath**


### PR DESCRIPTION
Hi @hhff, I've added the ability to pass in extra params that can be either static or dynamic. If the extra param is a property on the route, its value will be used for setting the extra param.

I hope this is an acceptable enhancement, I'm currently using this method to dynamically change the extra params I'm passing to the back-end.