### PR TITLE
keep loading until you are out of view

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -69,5 +69,9 @@ export default Ember.Component.extend({
     if (this.get('infinityModel.reachedInfinity') && this.get('destroyOnInfinity')) {
       this.destroy();
     }
+  }),
+
+  infinityModelPushed: Ember.observer('infinityModel.length', function() {
+    Ember.run.scheduleOnce('afterRender', this, this._checkIfInView);
   })
 });

--- a/tests/unit/components/infinity-loader-test.js
+++ b/tests/unit/components/infinity-loader-test.js
@@ -25,8 +25,7 @@ test('it will not destroy on load unless set', function(assert) {
     {id: 2, name: 'Potato'}
   ];
 
-  var component = this.subject();
-  component.set('infinityModel', infinityModelStub);
+  var component = this.subject({ infinityModel: infinityModelStub });
   this.render();
 
   assert.equal(component.get('destroyOnInfinity'), false);
@@ -53,8 +52,7 @@ test('it changes text property', function(assert) {
   ];
 
   var componentText;
-  var component = this.subject();
-  component.set('infinityModel', infinityModelStub);
+  var component = this.subject({ infinityModel: infinityModelStub });
   this.render();
 
   componentText = $.trim(component.$().text());
@@ -100,4 +98,31 @@ test('it throws error when multiple scrollable elements are found', function(ass
   assert.throws(function() {
     this.render();
   }, Error, "Should raise error");
+});
+
+test('it checks if in view after model is pushed', function(assert) {
+  assert.expect(4);
+
+  var infinityModelStub = Ember.A();
+  function pushModel() {
+    infinityModelStub.pushObject({});
+  }
+  pushModel();
+
+  var component = this.subject({ infinityModel: infinityModelStub });
+  component.set('_checkIfInView', function() {
+    assert.ok(true);
+  });
+  this.render();
+
+  var done = assert.async();
+  var count = 3;
+  for (var i = 0; i < 3; i++) {
+    setTimeout(() => {
+      Ember.run(pushModel);
+      if (!--count) {
+        done();
+      }
+    });
+  }
 });


### PR DESCRIPTION
In mobile view, the component is out of view on the first load. In desktop view, there is enough space for the component to load more a few times before being out of view. Currently the loader would not do anything because no scroll events occur.
This change will watch for pushes to the model and keep loading data if it is needed. The desktop view will fill up the screen on first page load.