### PR TITLE
extract `model.pushObjects` to a method

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,19 @@ and ember-infinity will be set up to parse the total number of pages from a JSON
 }
 ```
 
+You may override `updateInfinityModel` to customize how the route's `model` should be updated with new objects. You may also invoke this method directly to manually push new objects into the model:
+
+```js
+actions: {
+  pushHughIntoInfinityModel() [
+    var updatedInfinityModel = this.updateInfinityModel([
+      { id: 1, name: "Hugh Francis" }
+    ]);
+    console.log(updatedInfinityModel);
+  }
+}
+```
+
 ### infinityModel
 
 You can also provide additional parameters to `infinityModel` that

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -173,7 +173,6 @@ export default Ember.Mixin.create({
     var nextPage    = this.get('_currentPage') + 1;
     var perPage     = this.get('_perPage');
     var totalPages  = this.get('_totalPages');
-    var model       = this.get(this.get('_modelPath'));
     var modelName   = this.get('_infinityModelName');
 
     if (!this.get('_loadingMore') && this.get('_canLoadMore')) {
@@ -187,14 +186,14 @@ export default Ember.Mixin.create({
       var promise = this.store.find(modelName, params);
 
       promise.then(
-        infinityModel => {
-          model.pushObjects(infinityModel.get('content'));
+        newObjects => {
+          this.updateInfinityModel(newObjects);
           this.set('_loadingMore', false);
           this.set('_currentPage', nextPage);
           Ember.run.scheduleOnce('afterRender', this, 'infinityModelUpdated', {
             lastPageLoaded: nextPage,
             totalPages: totalPages,
-            newObjects: infinityModel
+            newObjects: newObjects
           });
           if (!this.get('_canLoadMore')) {
             this.set(this.get('_modelPath') + '.reachedInfinity', true);
@@ -215,6 +214,19 @@ export default Ember.Mixin.create({
       }
     }
     return false;
+  },
+
+  /**
+   Update the infinity model with new objects
+
+   @method updateInfinityModel
+   @param {Ember.Enumerable} newObjects The new objects to add to the model
+   @return {Ember.Array} returns the updated infinity model
+   */
+  updateInfinityModel(newObjects) {
+    var infinityModel = this.get(this.get('_modelPath'));
+
+    return infinityModel.pushObjects(newObjects.get('content'));
   },
 
   actions: {


### PR DESCRIPTION
...to allow overrides in the case when more specialized munging/manipulation might be required.

For one part of our app that needs infinite scroll, we have a slightly non-traditional API that requires a more complicated merging of our initial data and subsequent requests. This extremely minor change makes it much easier for us to use `ember-infinity` in that case.