### PR TITLE
Use Ember.get() to access store

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -1,5 +1,7 @@
 import Ember from 'ember';
 
+const { get } = Ember;
+
 /**
   The Ember Infinity Route Mixin enables an application route to load paginated
   records for the route `model` as triggered by the controller (or Infinity Loader
@@ -124,7 +126,7 @@ export default Ember.Mixin.create({
   */
   infinityModel(modelName, options, boundParams) {
 
-    if (Ember.isEmpty(this.store) || Ember.isEmpty(this.store.find)){
+    if (Ember.isEmpty(get(this, 'store')) || Ember.isEmpty(get(this, 'store').find)){
       throw new Ember.Error("Ember Data store is not available to infinityModel");
     } else if (modelName === undefined) {
       throw new Ember.Error("You must pass a Model Name to infinityModel");
@@ -155,7 +157,7 @@ export default Ember.Mixin.create({
     }
 
     var params = Ember.merge(requestPayloadBase, options);
-    var promise = this.store.find(modelName, params);
+    var promise = get(this, 'store').find(modelName, params);
 
     promise.then(
       infinityModel => {
@@ -201,7 +203,7 @@ export default Ember.Mixin.create({
       options = this._includeBoundParams(options, boundParams);
 
       var params = Ember.merge(requestPayloadBase, options);
-      var promise = this.store.find(modelName, params);
+      var promise = get(this, 'store').find(modelName, params);
 
       promise.then(
         newObjects => {
@@ -237,7 +239,7 @@ export default Ember.Mixin.create({
   /**
    include any bound params into the options object.
 
-   @method includeBoundParams 
+   @method includeBoundParams
    @param {Object} options, the object to include bound params into.
    @param {Object} boundParams, an object of properties to be included into options.
    @return {Object}

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -12,6 +12,7 @@ test('it works', assert => {
 
 test('it can not use infinityModel without Ember Data Store', assert => {
   var RouteObject = Ember.Route.extend(RouteMixin, {
+    store: null,
     model() {
       return this.infinityModel('post');
     }
@@ -73,7 +74,7 @@ test('it sets state before it reaches the end', assert => {
     }
   };
 
-  route.store = dummyStore;
+  route.set('store', dummyStore);
 
   var model;
   Ember.run(() => {
@@ -110,7 +111,7 @@ test('it allows customizations of request params', assert => {
     }
   };
 
-  route.store = dummyStore;
+  route.set('store', dummyStore);
 
   var model;
   Ember.run(() => {
@@ -142,7 +143,7 @@ test('it allows customizations of meta parsing params', assert => {
     }
   };
 
-  route.store = dummyStore;
+  route.set('store', dummyStore);
 
   var model;
   Ember.run(() => {
@@ -176,7 +177,7 @@ test('it sets state  when it reaches the end', assert => {
     }
   };
 
-  route.store = dummyStore;
+  route.set('store', dummyStore);
 
   var model;
   Ember.run(() => {
@@ -218,7 +219,7 @@ test('it uses extra params when loading more data', assert => {
     }
   };
 
-  route.store = dummyStore;
+  route.set('store', dummyStore);
 
   var model;
   Ember.run(() => {
@@ -280,7 +281,7 @@ test('it uses overridden params when loading more data', assert => {
     }
   };
 
-  route.store = dummyStore;
+  route.set('store', dummyStore);
 
   var model;
   Ember.run(() => {
@@ -338,7 +339,7 @@ test('it uses bound params when loading more data', assert => {
     }
   };
 
-  route.store = dummyStore;
+  route.set('store', dummyStore);
 
   var model;
   Ember.run(() => {
@@ -401,7 +402,7 @@ test('it allows overrides/manual invocations of updateInfinityModel', assert => 
     }
   };
 
-  route.store = dummyStore;
+  route.set('store', dummyStore);
 
   var model;
   Ember.run(() => {


### PR DESCRIPTION
I'm playing with a few interesting use cases, which involve using the "route.js" mixin on objects other than a route (i.e., an `Ember.Service` or something).

Allowing the store to be accessed is not a big problem -- I can just add a CP on this object
```js
  store: computed({
    get() {
      return this.container.lookup('store:main');
    }
  }),
```

Unfortunately, accessing this CP directly via a `this.store`, before the CP's getter function has been invoked for the first time, will end up returning the computed property its self, rather than the property's value. 

This small change should maintain the existing use cases just fine, and also allow for potential usage that deviates from the well-traveled path. 