### PR TITLE
dont rely on didInsertElement setting up scrollable

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import emberVersionIs from 'ember-version-is';
 import layout from '../templates/components/infinity-loader';
 
 export default Ember.Component.extend({
@@ -14,8 +15,21 @@ export default Ember.Component.extend({
   developmentMode: false,
   scrollable: null,
 
+  didRender() {
+    this._super(...arguments);
+    if(emberVersionIs('greaterThanOrEqualTo', "1.13.0")) {
+      this._setup();
+    }
+  },
+
   didInsertElement() {
     this._super(...arguments);
+    if(emberVersionIs('lessThan', "1.13.0")) {
+      this._setup();
+    }
+  },
+
+  _setup() {
     this._setupScrollable();
     this.set('guid', Ember.guidFor(this));
     this._bindEvent('scroll');

--- a/index.js
+++ b/index.js
@@ -8,5 +8,13 @@ module.exports = {
 
   init: function() {
     checker.assertAbove(this, '0.2.0');
+  },
+
+  included: function(app) {
+    this.addons.forEach(function(addon){
+     if (addon.name === "ember-version-is") {
+       addon.included.apply(addon, [app]);
+     }
+   });
   }
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
   "dependencies": {
     "ember-cli-babel": "^5.0.0",
     "ember-cli-htmlbars": "0.7.9",
-    "ember-cli-version-checker": "^1.0.2"
+    "ember-cli-version-checker": "^1.0.2",
+    "ember-version-is": "0.0.3"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config",

--- a/tests/acceptance/infinity-route-with-embedded-route-test.js
+++ b/tests/acceptance/infinity-route-with-embedded-route-test.js
@@ -1,0 +1,65 @@
+import Ember from 'ember';
+import { module, test } from 'qunit';
+import startApp from '../helpers/start-app';
+import Pretender from 'pretender';
+
+var App, server;
+
+var posts = [
+  { id: 1, name: "Squarepusher", category: "a" },
+  { id: 2, name: "Aphex Twin", category: "b" },
+  { id: 3, name: "Universal Indicator", category: "a" },
+  { id: 4, name: "Mike & Rich", category: "b" },
+  { id: 5, name: "Alroy Road Tracks", category: "a" },
+  { id: 6, name: "AFX", category: "b" }
+];
+
+module('Acceptance: Infinity Route', {
+  setup() {
+    App = startApp();
+    server = new Pretender(function() {
+      this.get('/posts', function(request) {
+        var body, subset, perPage, startPage, offset;
+
+        if (request.queryParams.category) {
+          subset = posts.filter(post => {
+            return post.category === request.queryParams.category;
+          });
+        } else {
+          subset = posts;
+        }
+        perPage = parseInt(request.queryParams.per_page, 10);
+        startPage = parseInt(request.queryParams.page, 10);
+
+        var pageCount = Math.ceil(subset.length / perPage);
+        offset = perPage * (startPage - 1);
+        subset = subset.slice(offset, offset + perPage);
+
+        body = { posts: subset, meta: { total_pages: pageCount } };
+
+        return [200, {"Content-Type": "application/json"}, JSON.stringify(body)];
+      });
+    });
+  },
+  teardown() {
+    Ember.run(App, 'destroy');
+    server.shutdown();
+  }
+});
+
+test('it works when embedded route is refreshed', assert => {
+  visit('/posts/1');
+  click('button.refreshRoute');
+
+  andThen(() => {
+    assert.equal(find('ul').find('li').length, 2);
+
+    var testList = find('ul');
+    testList.scrollTop(2000);
+    triggerEvent('ul', 'scroll');
+
+    andThen(() => {
+      assert.equal(find('ul').find('li').length > 2, true);
+    });
+  });
+});

--- a/tests/dummy/app/posts/route.js
+++ b/tests/dummy/app/posts/route.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import InfinityRoute from 'ember-infinity/mixins/route';
+
+export default Ember.Route.extend(InfinityRoute, {
+  model: function() {
+    return this.infinityModel('post', {perPage: 1, startingPage: 1});
+  }
+});

--- a/tests/dummy/app/posts/show/controller.js
+++ b/tests/dummy/app/posts/show/controller.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+
+export default Ember.Controller.extend({
+  actions: {
+    refreshRoute: function() {
+      this.get('target.router').refresh();
+    }
+  }
+});

--- a/tests/dummy/app/posts/show/route.js
+++ b/tests/dummy/app/posts/show/route.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  model: function(params) {
+    return this.store.find('post', params.post);
+  },
+});

--- a/tests/dummy/app/posts/show/template.hbs
+++ b/tests/dummy/app/posts/show/template.hbs
@@ -1,0 +1,3 @@
+<h2 id="posts-title">{{model.name}}</h2>
+
+<button {{action 'refreshRoute'}} class='refreshRoute'>Refresh route</button>

--- a/tests/dummy/app/posts/template.hbs
+++ b/tests/dummy/app/posts/template.hbs
@@ -1,0 +1,11 @@
+<h2 id="posts-title">Listing Posts</h2>
+
+<ul class="test-list" style='height: 100px; overflow: scroll;'>
+  {{#each model as |post|}}
+    <li>{{post.name}}</li>
+  {{/each}}
+  <li id='scollable-list-item'>{{infinity-loader infinityModel=model scrollable='.test-list' }}</li>
+</ul>
+
+
+{{outlet}}

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -9,6 +9,9 @@ Router.map(function() {
   this.route('demo', {path: '/'});
   this.route('home', { path: 'test' });
   this.route('category', { path: '/category/:category' });
+  this.resource('posts', function() {
+    this.route('show', { path: '/:post' });
+  });
 });
 
 export default Router;


### PR DESCRIPTION
In the project I'm working on currently we had problems with embedded routes and refreshing.

After refreshing the embedded route, the ember-infinity component would get re-initialized, without didInsertElement getting called. Thus the _setScrollable function was never called to set up the jquery object and we we're getting an error stating that "scrollable.height" is not a function.

I will add a test case in the course of the day to demonstrate the problem.

Cheers
Manuel Arno Korfmann 