### PR TITLE
Added "offset" option

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -12,6 +12,7 @@ export default Ember.Component.extend({
   destroyOnInfinity: false,
   developmentMode: false,
   scrollable: null,
+  offset: 0,
 
   didRender() {
     this._super(...arguments);
@@ -52,7 +53,7 @@ export default Ember.Component.extend({
   },
 
   _checkIfInView() {
-    var selfOffset       = this.$().offset().top;
+    var selfOffset       = this.$().offset().top - this.get('offset');
     var scrollable       = this.get("scrollable");
     var scrollableBottom = scrollable.height() + scrollable.scrollTop();
 


### PR DESCRIPTION
Small feature for developers who want to fetch more content before reaching the bottom of the page. eg.: {{infinity-loader infinityModel=myModel  offset="200"}}, where "200" is equivalent to 200px before reaching the bottom of the page.