### PR TITLE
Add afterInfinityModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,38 @@ setupController: function(controller, model) {
   controller.set('products', model);
 }
 ```
+### afterInfinityModel
+
+In some cases, a single call to your data store isn't enough. The afterInfinityModel method is available for those cases when you need to
+chain together functions or promises after fetching a model.
+
+As a simple example, let's say you had a blog and just needed to set a property on each Post model after fetching all of them:
+
+```js
+model: function() {
+  return this.infinityModel("post");
+},
+
+afterInfinityModel: function(posts) {
+  posts.setEach('author', 'Jane Smith');
+}
+```
+
+As a more complex example, let's say you had a blog with Posts and Authors as separate related models and you needed to fetch one followed
+by the other before returning anything. In that case, afterInfinityModel would allow you to do something like this:
+
+```js
+model: function() {
+  return this.infinityModel("post");
+},
+
+afterInfinityModel: function(posts) {
+  Ember.RSVP.Promise(posts.map(function(post) {
+    post.get('author')
+  }));
+}
+```
+
 ### Event Hooks
 
 The route mixin also provides following event hooks:

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -200,6 +200,23 @@ export default Ember.Mixin.create({
   },
 
   /**
+   Call additional functions after finding the infinityModel in the Ember data store.
+   @private
+   @method _afterInfinityModel
+   @param {Function} infinityModelPromise The resolved result of the Ember store find method. Passed in automatically.
+   @return {Ember.RSVP.Promise}
+  */
+  _afterInfinityModel(_this) {
+    return function(infinityModelPromiseResult) {
+      if (typeof _this.afterInfinityModel === 'function') {
+        return _this.afterInfinityModel(infinityModelPromiseResult);
+      } else {
+        return infinityModelPromiseResult;
+      }
+    };
+  },
+
+  /**
    Trigger a load of the next page of results.
 
    @private
@@ -250,7 +267,8 @@ export default Ember.Mixin.create({
     const nextPage    = this.incrementProperty('currentPage');
     const params      = this._buildParams(nextPage);
 
-    return this.store[this._storeFindMethod](modelName, params);
+    return this.store[this._storeFindMethod](modelName, params).then(
+      this._afterInfinityModel(this));
   },
 
   /**

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -435,6 +435,78 @@ test('It allows to set startingPage as 0', assert => {
   assert.equal(true, route.get('_canLoadMore'));
 });
 
+test('it calls the afterInfinityModel method on objects fetched from the store', assert => {
+  var RouteObject = Ember.Route.extend(RouteMixin, {
+    model() {
+      return this.infinityModel('item');
+    },
+    afterInfinityModel(items) {
+      return items.setEach('author', 'F. Scott Fitzgerald');
+    }
+  });
+
+  var route = RouteObject.create();
+
+  var dummyStore = {
+    query() {
+      var item = { id: 1, title: 'The Great Gatsby' };
+      return new Ember.RSVP.Promise(resolve => {
+        Ember.run(this, resolve, Ember.ArrayProxy.create({
+          content: Ember.A([item])
+        }));
+      });
+    }
+  };
+
+  route.set('store', dummyStore);
+
+  var model;
+  Ember.run(() => {
+    route.model().then(result => {
+      model = result;
+    });
+  });
+
+  assert.equal(model.get('content.firstObject.author'), 'F. Scott Fitzgerald', 'updates made in afterInfinityModel should take effect');
+});
+
+test('it resolves promises returned by the afterInfinityModel method', assert => {
+  var RouteObject = Ember.Route.extend(RouteMixin, {
+    model() {
+      return this.infinityModel('item');
+    },
+    afterInfinityModel(items) {
+      return new Ember.RSVP.Promise((resolve) => {
+        resolve(items.setEach('author', 'F. Scott Fitzgerald'));
+      });
+    }
+  });
+
+  var route = RouteObject.create();
+
+  var dummyStore = {
+    query() {
+      var item = { id: 1, title: 'The Great Gatsby' };
+      return new Ember.RSVP.Promise(resolve => {
+        Ember.run(this, resolve, Ember.ArrayProxy.create({
+          content: Ember.A([item])
+        }));
+      });
+    }
+  };
+
+  route.set('store', dummyStore);
+
+  var model;
+  Ember.run(() => {
+    route.model().then(result => {
+      model = result;
+    });
+  });
+
+  assert.equal(model.get('content.firstObject.author'), 'F. Scott Fitzgerald', 'updates made in afterInfinityModel should take effect');
+});
+
 /*
  * Compatibility Tests
  */


### PR DESCRIPTION
In the application that I'm working on, there are many cases where `get(this, 'store').find(modelName, params)` is not the end of the promise chain before we hand the fetched models to the route. This PR adds that functionality.

I tried to follow the conventions that I could see for declaring private parameters, using the options object, and deleting keys after creating variables for them. That said, it does seem a little odd to have an `_afterModelPromise` private property, and you might have better suggestions for how things should be named.