### PR TITLE
Reduce duplication in route

### DIFF
--- a/tests/integration/infinity-loader-test.js
+++ b/tests/integration/infinity-loader-test.js
@@ -7,7 +7,9 @@ moduleForComponent('infinity-loader', {
 
 test('it renders loading text if no block given', function(assert) {
   assert.expect(1);
+  this.send = function () {};
   this.on('infinityLoad', function () {});
+
   this.render(hbs`
               {{infinity-loader}}
               `);
@@ -16,7 +18,9 @@ test('it renders loading text if no block given', function(assert) {
 
 test('it yields to the block if given', function(assert) {
   assert.expect(1);
+  this.send = function () {};
   this.on('infinityLoad', function () {});
+
   this.render(hbs`
               {{#infinity-loader}}
                 <span>My custom block</span>


### PR DESCRIPTION
This branch is motivated in anticipation of some upcoming bugfixes. The state of the route is difficult to reason about due to numerous duplications and minor inconsistencies between the initial load and page 2+ loads. This branch attempts to bring them into line with each other. No tests have been changed, because no behavior has been changed.