### PR TITLE
Call update model on first page load

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -285,6 +285,11 @@ export default Ember.Mixin.create({
    @return {Ember.Array} returns the new objects
    */
   updateInfinityModel(newObjects) {
+    if (!this.get('_firstPageLoaded')) {
+      // the first set of newObjects becomes infinityModel
+      return newObjects;
+    }
+
     let infinityModel = this._infinityModel();
     return infinityModel.pushObjects(newObjects.get('content'));
   },
@@ -300,11 +305,7 @@ export default Ember.Mixin.create({
     const totalPages = newObjects.get(this.get('totalPagesParam'));
     this.set('_totalPages', totalPages);
 
-    let infinityModel = newObjects;
-
-    if (this.get('_firstPageLoaded')) {
-      infinityModel = this.updateInfinityModel(newObjects);
-    }
+    let infinityModel = this.updateInfinityModel(newObjects);
 
     this.set('_firstPageLoaded', true);
     this._notifyInfinityModelUpdated(newObjects);

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -559,7 +559,7 @@ test('it allows overrides/manual invocations of updateInfinityModel', assert => 
 
   assert.equal(route.get('_canLoadMore'), true, '_canLoadMore');
   assert.equal(model.get('content.length'), 1, 'content.length');
-  assert.notEqual(model.get('content.lastObject.author'), 'F. Scott Fitzgerald', 'overrides to updateInfinityModel should take effect');
+  assert.equal(model.get('content.lastObject.author'), 'F. Scott Fitzgerald', 'overrides to updateInfinityModel should take effect');
 
   Ember.run(() => {
     route._infinityLoad();


### PR DESCRIPTION
Fixes a bug in ember-infinity. See: https://github.com/hhff/ember-infinity/issues/90

In short, there was no effective hook to update `boundParams` after the first page loads, but before the second page is requested. This PR fixes that.
