### PR TITLE
Upgrade ember-qunit

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -6,7 +6,7 @@
     "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
     "ember-data": "1.13.9",
     "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.9",
+    "ember-qunit": "0.4.16",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",


### PR DESCRIPTION
Per Ember 2.3.0-beta1 release notes (http://emberjs.com/blog/2015/11/16/ember-2-2-released.html), "ember-qunit 0.4.16+ is required for use with Ember 2.3." This upgrades ember-qunit which is all that's required to fix 2.3 compatibility. This fixes https://github.com/hhff/ember-infinity/issues/103