### PR TITLE
Update README, push new record to infinityModel

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,23 @@ afterInfinityModel(posts) {
 }
 ```
 
+### Push new record to infinityModel
+
+`createRecord` will not auto update infinityModel.
+
+```
+var post = this.store.createRecord('post', {
+  body: body,
+});
+
+// Push new record
+this.get('controller.model').unshiftObject(post._internalModel);
+
+// Delete pushed record
+this.get('controller.model').removeObject(post);
+
+```
+
 ### Event Hooks
 
 The route mixin also provides following event hooks:


### PR DESCRIPTION
 Use case:

- List of posts to be displayed below text area. User can add new post in the list.

New post is created using `createRecord` api, post get created but posts 
list does not get updated because `ember-infinity` uses `query` method to load data.

Data loaded using `query` is static and it does not update if new record is added in `store`. 

I spent whole day to figure this out, may be it will save other developers time.

