### PR TITLE
Changed references to this.store in order to allow using the mixin inside components

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -156,7 +156,7 @@ const RouteMixin = Ember.Mixin.create({
   },
 
   /**
-    Use the infinityModel method in the place of `this.get('store').find('model')` to
+    Use the infinityModel method in the place of `this.store.find('model')` to
     initialize the Infinity Model for your route.
 
     @method infinityModel

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -146,7 +146,7 @@ const RouteMixin = Ember.Mixin.create({
       throw new Ember.Error("Ember Infinity: You are using an unsupported version of Ember Data.  Please upgrade to at least 1.13.4 or downgrade to 1.0.0-beta.19.2");
     }
 
-    if (Ember.isEmpty(this.store) || Ember.isEmpty(this.store[this._storeFindMethod])){
+    if (Ember.isEmpty(this.get('store')) || Ember.isEmpty(this.get('store')[this._storeFindMethod])){
       throw new Ember.Error("Ember Infinity: Ember Data store is not available to infinityModel");
     }
 
@@ -156,7 +156,7 @@ const RouteMixin = Ember.Mixin.create({
   },
 
   /**
-    Use the infinityModel method in the place of `this.store.find('model')` to
+    Use the infinityModel method in the place of `this.get('store').find('model')` to
     initialize the Infinity Model for your route.
 
     @method infinityModel
@@ -270,7 +270,7 @@ const RouteMixin = Ember.Mixin.create({
     const nextPage    = this.incrementProperty('currentPage');
     const params      = this._buildParams(nextPage);
 
-    return this.store[this._storeFindMethod](modelName, params).then(
+    return this.get('store')[this._storeFindMethod](modelName, params).then(
       this._afterInfinityModel(this));
   },
 


### PR DESCRIPTION
I had the same problem mentioned in #93 issue. I'd like to use the mixin inside components, not in routes. Actually it would be nice to have reference to `this.get('store')` instead `this.store`. I don't have injected `store` to each component, so it's not possible to use `this.store` statement even I explicitly inject by `store: Ember.inject.service()`. Furthermore this change doesn't affect nothing more, so it only extend the configurability.