### PR TITLE
verbose version of "Could not fetch Infinity Model"

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -249,8 +249,8 @@ const RouteMixin = Ember.Mixin.create({
 
         return newObjects;
       },
-      () => {
-        throw new Ember.Error("Ember Infinity: Could not fetch Infinity Model. Please check your serverside configuration.");
+      (ex) => {
+        throw new Ember.Error("Ember Infinity: Could not fetch Infinity Model. Please check your serverside configuration. Error: " + ex);
       }
     )
     .finally(() => {

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -250,7 +250,13 @@ const RouteMixin = Ember.Mixin.create({
         return newObjects;
       },
       (ex) => {
-        throw new Ember.Error("Ember Infinity: Could not fetch Infinity Model. Please check your serverside configuration. Error: " + ex);
+        var errorMessage;
+        if (typeof(ex) === 'string'){
+          errorMessage = ex;
+        } else {
+          errorMessage = (ex.message || ex.responseText || 'undefined error');
+        }
+        throw new Ember.Error("Ember Infinity: Could not fetch Infinity Model. Error: " + errorMessage);
       }
     )
     .finally(() => {

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -500,6 +500,21 @@ test('it resolves a promise returned from afterInfinityModel', function (assert)
   this.assertAfterInfinityWorks(assert);
 });
 
+test('error "Could not fetch Infinity Model" should include RSVP rejection message', assert => {
+  var route = createRoute(['post'], {
+    store: {
+      query() {
+        return Ember.RSVP.reject(new Error("I don't like this API"));
+      }
+    }
+  });
+
+  return route.model().then(function() {
+      assert.ok(false, "promise should not be fulfilled");
+    })['catch'](function(err) {
+      assert.equal(err.message, "Ember Infinity: Could not fetch Infinity Model. Error: I don't like this API");
+    });
+});
 
 /*
  * Compatibility Tests


### PR DESCRIPTION
Displays the error message related to the exception that triggers the “Ember Infinity: Could not fetch Infinity Model” error, making debugging a little easier. 