### PR TITLE
Don't swallow errors when loading records

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -248,14 +248,10 @@ const RouteMixin = Ember.Mixin.create({
         this._nextPageLoaded(newObjects);
 
         return newObjects;
-      },
-      () => {
-        throw new Ember.Error("Ember Infinity: Could not fetch Infinity Model. Please check your serverside configuration.");
-      }
-    )
-    .finally(() => {
-      this.set('_loadingMore', false);
-    });
+      })
+      .finally(() => {
+        this.set('_loadingMore', false);
+      });
   },
 
   /**


### PR DESCRIPTION
The default behavior would swallow all errors that could occur while loading records and prints an obscure error message.

This is bad because:
-  When you read the error, you don't know what to do - there is no description of a "right" serverside configuration.
- When you override the `afterInfinityModel` hook, it won't display possible errors - this took me a few minutes to figure out what's wrong.
- When an error occurs while loading the resource (i.e 500 error), the default error ember handling will be ignored - The user is left in a broken UI state and you have no chance to fix this.

It's safer to leave the original error messages as is and don't swallow errors in favor of a more generic one.