### PR TITLE
Pin jQuery to Ember.js compatible version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,7 +9,7 @@
     "ember-qunit": "0.4.17",
     "ember-qunit-notifications": "0.0.7",
     "ember-resolver": "~0.1.18",
-    "jquery": "^1.11.3",
+    "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
     "pretender": "^0.9.0",


### PR DESCRIPTION
Fixes Testem not running at all on a fresh install.