### PR TITLE
Stop calling _loadMoreIfNeeded() as a scheduled task if component is destroyed

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -64,6 +64,9 @@ const InfinityLoaderComponent = Ember.Component.extend({
   },
 
   _loadMoreIfNeeded() {
+    if (this.isDestroyed) {
+      return;
+    }
     if (this._shouldLoadMore()) {
       this.sendAction('loadMoreAction');
     }


### PR DESCRIPTION
Problem: Calling _loadMoreIfNeeded() as a scheduled task when the component is destroyed will error out.

Fix: Prevent from calling loadMoreAction from _loadMoreIfNeeded() when the component is destroyed.