### PR TITLE
Demo of acceptance test problems when using a scrollable window

### DIFF
--- a/tests/acceptance/infinity-route-offset-trigger-test.js
+++ b/tests/acceptance/infinity-route-offset-trigger-test.js
@@ -58,12 +58,21 @@ function triggerOffset() {
   return list.get(0).scrollHeight - list.height();
 }
 
+function triggerWindowOffset() {
+  var tmpWindow = Ember.$(window);
+  return tmpWindow.get(0).scrollHeight - tmpWindow.height();
+}
+
 function shouldBeItemsOnTheList(assert, amount) {
   assert.equal(postList().find('li').length, amount, `${amount} items should be in the list`);
 }
 
 function scrollTo(offset) {
   postList().scrollTop(offset);
+}
+
+function scrollToWindow(offset) {
+  Ember.$(window).scrollTop(offset);
 }
 
 function infinityShouldNotBeReached(assert) {
@@ -108,17 +117,23 @@ test('it should start loading more items when the scroll is on the very bottom '
   andThen(() => {
     shouldBeItemsOnTheList(assert, 25);
     infinityShouldNotBeReached(assert);
-    scrollTo(triggerOffset() - 100);
+    scrollToWindow(triggerWindowOffset() - 100);
   });
 
-  triggerEvent('ul', 'scroll');
+  andThen(() => {
+    // can't use Ember's triggerEvent as we can't use a 'window' selector ...
+    Ember.$(window).scroll();
+  });
 
   andThen(() => {
     shouldBeItemsOnTheList(assert, 25);
-    scrollTo(triggerOffset() + 100);
+    scrollToWindow(triggerWindowOffset() + 100);
+    //Ember.$(window).scrollTop(2000); (doesn't seem to work either)
   });
 
-  triggerEvent('ul', 'scroll');
+  andThen(() => {
+    Ember.$(window).scroll();
+  });
 
   andThen(() => {
     shouldBeItemsOnTheList(assert, 50);

--- a/tests/acceptance/infinity-route-offset-trigger-test.js
+++ b/tests/acceptance/infinity-route-offset-trigger-test.js
@@ -101,6 +101,31 @@ test('it should start loading more items when the scroll is on the very bottom '
   });
 });
 
+test('it should start loading more items when the scroll is on the very bottom ' +
+  'when triggerOffset is not set and our scrollable element is the window', assert => {
+  visit('/test-window-scrollable');
+
+  andThen(() => {
+    shouldBeItemsOnTheList(assert, 25);
+    infinityShouldNotBeReached(assert);
+    scrollTo(triggerOffset() - 100);
+  });
+
+  triggerEvent('ul', 'scroll');
+
+  andThen(() => {
+    shouldBeItemsOnTheList(assert, 25);
+    scrollTo(triggerOffset() + 100);
+  });
+
+  triggerEvent('ul', 'scroll');
+
+  andThen(() => {
+    shouldBeItemsOnTheList(assert, 50);
+    infinityShouldBeReached(assert);
+  });
+});
+
 test('it should start loading more items before the scroll is on the very bottom ' +
   'when triggerOffset is set', assert => {
   visit('/test-scrollable?triggerOffset=200');

--- a/tests/dummy/app/controllers/test-window-scrollable.js
+++ b/tests/dummy/app/controllers/test-window-scrollable.js
@@ -1,0 +1,6 @@
+import Ember from 'ember';
+
+export default Ember.Controller.extend({
+  queryParams: ['triggerOffset'],
+  triggerOffset: 0
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ Router.map(function() {
   this.route('demo-scrollable', { path: '/demo-scrollable' });
   this.route('home', { path: 'test' });
   this.route('test-scrollable', { path: '/test-scrollable' });
+  this.route('test-window-scrollable', { path: '/test-window-scrollable' });
   this.route('category', { path: '/category/:category' });
   this.resource('posts', function() {
     this.route('show', { path: '/:post' });

--- a/tests/dummy/app/routes/test-window-scrollable.js
+++ b/tests/dummy/app/routes/test-window-scrollable.js
@@ -1,0 +1,8 @@
+import Ember from 'ember';
+import InfinityRoute from 'ember-infinity/mixins/route';
+
+export default Ember.Route.extend(InfinityRoute, {
+  model: function() {
+    return this.infinityModel('post');
+  }
+});

--- a/tests/dummy/app/templates/test-window-scrollable.hbs
+++ b/tests/dummy/app/templates/test-window-scrollable.hbs
@@ -7,7 +7,6 @@
 
   {{infinity-loader
     infinityModel=model
-    scrollable="#test-list"
     triggerOffset=triggerOffset
     loadingText="loading"
     loadedText="loaded"

--- a/tests/dummy/app/templates/test-window-scrollable.hbs
+++ b/tests/dummy/app/templates/test-window-scrollable.hbs
@@ -1,0 +1,15 @@
+<h2 id="posts-title">Listing Posts</h2>
+
+<ul id="test-list" class="test-list test-list-scrollable">
+  {{#each model as |post|}}
+    <li>{{post.name}}</li>
+  {{/each}}
+
+  {{infinity-loader
+    infinityModel=model
+    scrollable="#test-list"
+    triggerOffset=triggerOffset
+    loadingText="loading"
+    loadedText="loaded"
+  }}
+</ul>


### PR DESCRIPTION
Howdy, I've been enjoying using your add-on and it looks like it's going to be a great help on our end.

I've been writing an acceptance test to confirm that everything is working in our app (and that things are running smoothly).  We're not specifying a `scrollable` element, but letting it default to `window`.  I'm either missing something really simple (which may be possible :smile: ) or it's not currently testable as an acceptance test.  I've tried a variety of approaches (see the test file) but can't get it to work.

I'm sending over an acceptance test that is almost a mirror image of the same test that is working (when `scrollable` is set).  Any thoughts?