### PR TITLE
Fixed race condition issue

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -133,6 +133,14 @@ const RouteMixin = Ember.Mixin.create({
   }),
 
   /**
+    @private
+    @property _infinityModelId
+    @type Integer
+    @default 0
+  */
+  _infinityModelId: 0,
+
+  /**
    @private
    @method _infinityModel
    @return {DS.RecordArray} the model
@@ -169,7 +177,7 @@ const RouteMixin = Ember.Mixin.create({
     if (emberDataVersionIs('lessThan', '1.13.0')) {
       this.set('_storeFindMethod', 'find');
     }
-
+    this.incrementProperty('_infinityModelId');
     this.set('_infinityModelName', modelName);
 
     this._ensureCompatibility();
@@ -243,11 +251,14 @@ const RouteMixin = Ember.Mixin.create({
   _loadNextPage() {
     this.set('_loadingMore', true);
 
+    var infinityModelId = this.get('_infinityModelId');
     return this._requestNextPage()
       .then((newObjects) => {
-        this._nextPageLoaded(newObjects);
-
-        return newObjects;
+        if(this.get('_infinityModelId') === infinityModelId) {
+          return this._nextPageLoaded(newObjects);
+        } else {
+          return [];
+        }
       })
       .finally(() => {
         this.set('_loadingMore', false);


### PR DESCRIPTION
I spotted an issue with race condition of requests using ember-infinity. 

Let's say we have an implementation of ember-infinity in a search engine. You entered `X` phrase and scrolled down so a next bunch of data started loading. Then you quickly changed the search query to `Y`. Then we can have a case when the second bunch of data (for the `X` phrase) is still loading and the first bunch of data for the `Y` search query is already loaded. When the second bunch of data for `X` query is being finally loaded, the data is append to the results of `Y`. 

This change resolved my problem. Would be nice to merge it into master :)

Any suggestions? :)