### PR TITLE
Prevent load more action when component is destroying or destroyed

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -56,7 +56,7 @@ const InfinityLoaderComponent = Ember.Component.extend({
   },
 
   _shouldLoadMore() {
-    if (this.get('developmentMode')) {
+    if (this.get('developmentMode') || this.isDestroying || this.isDestroyed) {
       return false;
     }
 


### PR DESCRIPTION
This should fix #100 and is corrected version of #138.