### PR TITLE
Skip pagination parameters when set to null 

### DIFF
--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -285,8 +285,14 @@ const RouteMixin = Ember.Mixin.create({
    */
   _buildParams(nextPage) {
     const pageParams = {};
-    pageParams[this.get('perPageParam')] = this.get('_perPage');
-    pageParams[this.get('pageParam')] = nextPage;
+
+    if(this.get('perPageParam')){
+      pageParams[this.get('perPageParam')] = this.get('_perPage');
+    }
+
+    if(this.get('pageParam')){
+      pageParams[this.get('pageParam')] = nextPage;
+    }
 
     const params = assign(pageParams, this.get('_extraParams'));
 

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -130,6 +130,23 @@ test('it allows customizations of request params', assert => {
   callModelHook(route);
 });
 
+test('it skips request params when set to null', assert => {
+  var store = createMockStore(
+    EO({ items: [] }),
+    function (modelType, findQuery) {
+      assert.deepEqual(findQuery, {}, 'findQuery');
+  });
+
+  var route = createRoute(['item'], {
+    perPageParam: null,
+    pageParam: null,
+    store
+  });
+
+  callModelHook(route);
+});
+
+
 test('it allows customizations of meta parsing params', assert => {
   var store = createMockStore(EO({
     items: [{id: 1, name: 'Walter White'}],


### PR DESCRIPTION
Hi.
In my server (which is based on cursor pagination) I have to make sure no extra parameters are set.
Therefore I try to set perPageParam and pageParam to null.

Unfortunately I noticed the parameters still get added like this:

$URL?...&null=2&...
I write a patch to completely exclude parameters when the names are not set.
Hope you like it!
  Paolo
