### PR TITLE
Use new super format from init to avoid deprecation warnings

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,9 @@ module.exports = {
   name: 'ember-infinity',
 
   init: function() {
+    if (this._super.init) {
+      this._super.init.apply(this, arguments);
+    }
     checker.assertAbove(this, '0.2.0');
   },
 

--- a/tests/dummy/app/routes/demo-scrollable.js
+++ b/tests/dummy/app/routes/demo-scrollable.js
@@ -16,7 +16,9 @@ function generateFakeData(qty) {
 
 export default Ember.Route.extend(InfinityRoute, {
   init: function () {
-    this._super(...arguments);
+    if (this._super.init) {
+      this._super.init.apply(this, arguments);
+    }
     var fakeData = generateFakeData(104);
     this.set('pretender', new Pretender());
     this.get('pretender').get('/posts', request => {

--- a/tests/dummy/app/routes/demo.js
+++ b/tests/dummy/app/routes/demo.js
@@ -16,7 +16,9 @@ function generateFakeData(qty) {
 
 export default Ember.Route.extend(InfinityRoute, {
   init: function () {
-    this._super(...arguments);
+    if (this._super.init) {
+      this._super.init.apply(this, arguments);
+    }
     var fakeData = generateFakeData(104);
     this.set('pretender', new Pretender());
     this.get('pretender').get('/posts', request => {


### PR DESCRIPTION
We have ember-infinity as a dependency and on newer versions of Ember we're getting a deprecation warning due to `index.js` not calling super from init:

```
DEPRECATION: Overriding init without calling this._super is deprecated. Please call `this._super.init && this._super.init.apply(this, arguments);` addon: `ember-infinity`
    at Function.Addon.lookup (/Users/mattdentremont/git/aiotv-admin/node_modules/ember-cli/lib/models/addon.js:896:27)
```