### PR TITLE
Use ember-in-viewport for handling scrolling at 60fps

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,14 +81,14 @@ and will expect to receive metadata in the response payload via a `total_pages` 
 }
 ```
 
-If you wish to customize some aspects of the JSON contract for pagination, you may do so via your routes. For example: 
+If you wish to customize some aspects of the JSON contract for pagination, you may do so via your routes. For example:
 
 ```js
 import Ember from 'ember';
 import InfinityRoute from "ember-infinity/mixins/route";
 
 export default Ember.Route.extend(InfinityRoute, {
-  
+
   perPageParam: "per",              // instead of "per_page"
   pageParam: "pg",                  // instead of "page"
   totalPagesParam: "meta.total",    // instead of "meta.total_pages"
@@ -104,7 +104,7 @@ This will result in request query params being sent out as follows
 
 ```
 /items?per=5&pg=1
-``` 
+```
 
 and ember-infinity will be set up to parse the total number of pages from a JSON response like this:
 
@@ -166,8 +166,8 @@ return this.infinityModel("product", { perPage: 12, startingPage: 1,
                                        category: "furniture" });
 ```
 
-Moreover, you can optionally pass in an object of bound parameters as a third option to `infinityModel` to further 
-customize the request to the backend. The values of the contained parameters will be looked up against the route 
+Moreover, you can optionally pass in an object of bound parameters as a third option to `infinityModel` to further
+customize the request to the backend. The values of the contained parameters will be looked up against the route
 properties and the respective values will be included in the request:
 
 ```js
@@ -371,15 +371,6 @@ component.
 
 Will install the default `infinity-loader` template into your host app, at
 `app/templates/components/infinity-loader`.
-
-* **scrollable**
-
-```hbs
-{{infinity-loader scrollable="#content"}}
-```
-
-You can optionally pass in a jQuery style selector string.  If it's not a string,
-scrollable will default to using the window for the scroll binding.
 
 * **triggerOffset**
 

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -1,102 +1,48 @@
 import Ember from 'ember';
 import emberVersionIs from 'ember-version-is';
+import InViewportMixin from 'ember-in-viewport';
 
-const InfinityLoaderComponent = Ember.Component.extend({
-  classNames: ["infinity-loader"],
-  classNameBindings: ["infinityModel.reachedInfinity"],
+const {
+  guidFor,
+  observer
+} = Ember;
+
+const InfinityLoaderComponent = Ember.Component.extend(InViewportMixin, {
+  classNames: ['infinity-loader'],
+  classNameBindings: ['infinityModel.reachedInfinity', 'viewportEntered:in-viewport'],
   guid: null,
-  eventDebounce: 10,
   loadMoreAction: 'infinityLoad',
   loadingText: 'Loading Infinite Model...',
   loadedText: 'Infinite Model Entirely Loaded.',
   destroyOnInfinity: false,
   developmentMode: false,
-  scrollable: null,
   triggerOffset: 0,
 
   didInsertElement() {
     this._super(...arguments);
-    this._setupScrollable();
-    this.set('guid', Ember.guidFor(this));
-    this._bindEvent('scroll');
-    this._bindEvent('resize');
-    this._loadMoreIfNeeded();
-  },
 
-  willDestroyElement() {
-    this._super(...arguments);
-    this._unbindEvent('scroll');
-    this._unbindEvent('resize');
-  },
-
-  _bindEvent(eventName) {
-    this.get('_scrollable').on(`${eventName}.${this.get('guid')}`, () => {
-      Ember.run.debounce(this, this._loadMoreIfNeeded, this.get('eventDebounce'));
+    this.setProperties({
+      guid: guidFor(this),
+      viewportSpy: true,
+      viewportTolerance: {
+        bottom : this.get('triggerOffset'),
+        top    : 0,
+        left   : 0,
+        right  : 0
+      }
     });
   },
 
-  _unbindEvent(eventName) {
-    this.get('_scrollable').off(`${eventName}.${this.get('guid')}`);
-  },
-
-  _selfOffset() {
-    if (this.get('_customScrollableIsDefined')) {
-      return this.$().position().top + this.get("_scrollable").scrollTop();
-    } else {
-      return this.$().offset().top;
-    }
-  },
-
-  _bottomOfScrollableOffset() {
-    return this.get('_scrollable').height() + this.get("_scrollable").scrollTop();
-  },
-
-  _triggerOffset() {
-    return this._selfOffset() - this.get('triggerOffset');
-  },
-
-  _shouldLoadMore() {
-    if (this.get('developmentMode') || this.isDestroying || this.isDestroyed) {
-      return false;
-    }
-
-    return this._bottomOfScrollableOffset() > this._triggerOffset();
-  },
-
-  _loadMoreIfNeeded() {
-    if (this._shouldLoadMore()) {
+  didEnterViewport() {
+    if(!this.get('infinityModel.reachedInfinity') && !this.get('developmentMode')) {
       this.sendAction('loadMoreAction');
     }
   },
 
-  _setupScrollable() {
-    var scrollable = this.get('scrollable');
-    if (Ember.typeOf(scrollable) === 'string') {
-      var items = Ember.$(scrollable);
-      if (items.length === 1) {
-        this.set('_scrollable', items.eq(0));
-      } else if (items.length > 1) {
-        throw new Error("Ember Infinity: Multiple scrollable elements found for: " + scrollable);
-      } else {
-        throw new Error("Ember Infinity: No scrollable element found for: " + scrollable);
-      }
-      this.set('_customScrollableIsDefined', true);
-    } else if (scrollable === undefined || scrollable === null) {
-      this.set('_scrollable', Ember.$(window));
-      this.set('_customScrollableIsDefined', false);
-    } else {
-      throw new Error("Ember Infinity: Scrollable must either be a css selector string or left empty to default to window");
-    }
-  },
-
-  loadedStatusDidChange: Ember.observer('infinityModel.reachedInfinity', 'destroyOnInfinity', function () {
+  loadedStatusDidChange: observer('infinityModel.reachedInfinity', 'destroyOnInfinity', function () {
     if (this.get('infinityModel.reachedInfinity') && this.get('destroyOnInfinity')) {
       this.destroy();
     }
-  }),
-
-  infinityModelPushed: Ember.observer('infinityModel.length', function() {
-    Ember.run.scheduleOnce('afterRender', this, this._loadMoreIfNeeded);
   })
 });
 

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -39,7 +39,7 @@ const InfinityLoaderComponent = Ember.Component.extend(InViewportMixin, {
     }
   },
 
-  loadedStatusDidChange: observer('infinityModel.reachedInfinity', 'destroyOnInfinity', function () {
+  destroyWhenReachedInfinity: observer('infinityModel.reachedInfinity', 'destroyOnInfinity', function () {
     if (this.get('infinityModel.reachedInfinity') && this.get('destroyOnInfinity')) {
       this.destroy();
     }

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -23,7 +23,10 @@ const InfinityLoaderComponent = Ember.Component.extend(InViewportMixin, {
     return guidFor(this);
   }).readOnly(),
 
-  setupViewportOptions: on('didInsertElement', function() {
+  didInsertElement() {
+    this._super(...arguments);
+
+    // Override viewport options
     this.setProperties({
       viewportSpy: true,
       viewportTolerance: {
@@ -33,7 +36,7 @@ const InfinityLoaderComponent = Ember.Component.extend(InViewportMixin, {
         right  : 0
       }
     });
-  }),
+  },
 
   didEnterViewport() {
     if(!this.get('infinityModel.reachedInfinity') && !this.get('developmentMode')) {

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -3,7 +3,6 @@ import emberVersionIs from 'ember-version-is';
 import InViewportMixin from 'ember-in-viewport';
 
 const {
-  on,
   guidFor,
   observer,
   computed

--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -3,14 +3,15 @@ import emberVersionIs from 'ember-version-is';
 import InViewportMixin from 'ember-in-viewport';
 
 const {
+  on,
   guidFor,
-  observer
+  observer,
+  computed
 } = Ember;
 
 const InfinityLoaderComponent = Ember.Component.extend(InViewportMixin, {
   classNames: ['infinity-loader'],
   classNameBindings: ['infinityModel.reachedInfinity', 'viewportEntered:in-viewport'],
-  guid: null,
   loadMoreAction: 'infinityLoad',
   loadingText: 'Loading Infinite Model...',
   loadedText: 'Infinite Model Entirely Loaded.',
@@ -18,11 +19,12 @@ const InfinityLoaderComponent = Ember.Component.extend(InViewportMixin, {
   developmentMode: false,
   triggerOffset: 0,
 
-  didInsertElement() {
-    this._super(...arguments);
+  guid: computed(function() {
+    return guidFor(this);
+  }).readOnly(),
 
+  setupViewportOptions: on('didInsertElement', function() {
     this.setProperties({
-      guid: guidFor(this),
       viewportSpy: true,
       viewportTolerance: {
         bottom : this.get('triggerOffset'),
@@ -31,7 +33,7 @@ const InfinityLoaderComponent = Ember.Component.extend(InViewportMixin, {
         right  : 0
       }
     });
-  },
+  }),
 
   didEnterViewport() {
     if(!this.get('infinityModel.reachedInfinity') && !this.get('developmentMode')) {

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
     "ember-cli-version-checker": "^1.0.2",
+    "ember-in-viewport": "^2.0.7",
     "ember-version-is": "0.0.3"
   },
   "ember-addon": {

--- a/tests/dummy/app/templates/demo-scrollable.hbs
+++ b/tests/dummy/app/templates/demo-scrollable.hbs
@@ -16,7 +16,6 @@
       loadingText="Loading more awesome records..."
       loadedText="Loaded all the records!"
       triggerOffset=500
-      scrollable=".demo-items"
     }}
   </ul>
 </div>

--- a/tests/dummy/app/templates/test-scrollable.hbs
+++ b/tests/dummy/app/templates/test-scrollable.hbs
@@ -7,7 +7,6 @@
 
   {{infinity-loader
     infinityModel=model
-    scrollable="#test-list"
     triggerOffset=triggerOffset
     loadingText="loading"
     loadedText="loaded"


### PR DESCRIPTION
Instead of attaching the infinity-loader to the window's scroll event, this will trigger an action when the loader component comes into view. Not only is the scrolling much smoother, but this also significantly reduces your code complexity. 

Im using the same technique in `ember-light-table` and it works really well 😸 

@hhff thoughts / concerns? 

