### PR TITLE
Fix loader with custom scrollable that never fires

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -41,7 +41,7 @@ const InfinityLoaderComponent = Ember.Component.extend({
 
   _selfOffset() {
     if (this.get('_customScrollableIsDefined')) {
-      return this.$().position().top + this.get("_scrollable").scrollTop();
+      return this.$().offset().top - this.get("_scrollable").offset().top + this.get("_scrollable").scrollTop();
     } else {
       return this.$().offset().top;
     }


### PR DESCRIPTION
Fixes #126 

Right now, if the scrollable is not the direct parent of the loader, then `position` will not give us what we want. Using `this.$().offset().top - this.get("_scrollable").offset().top` should always give us what we want though.