### PR TITLE
Only infinityLoad for this route's infinityModel

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -65,7 +65,7 @@ const InfinityLoaderComponent = Ember.Component.extend({
 
   _loadMoreIfNeeded() {
     if (this._shouldLoadMore()) {
-      this.sendAction('loadMoreAction');
+      this.sendAction('loadMoreAction', this.get('infinityModel'));
     }
   },
 

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -104,8 +104,12 @@ const RouteMixin = Ember.Mixin.create({
   totalPagesParam: 'meta.total_pages',
 
   actions: {
-    infinityLoad() {
-      this._infinityLoad();
+    infinityLoad(infinityModel) {
+      if (infinityModel === this._infinityModel()) {
+        this._infinityLoad();
+      } else {
+        return true;
+      }
     }
   },
 


### PR DESCRIPTION
Fixes #150

Before calling `this._infinityLoad()`, double check that it's actually this route's loader which raised the `infinityLoad` action, otherwise bubble the `infinityLoad` action.