### PR TITLE
Update load-more-button docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ export default Ember.Component.extend({
   loadText: 'Load more',
   loadedText: 'Loaded',
   click: function(){    
-    this.sendAction();  
+    this.sendAction('action', this.get('infinityModel'));
   }
 });
 ```


### PR DESCRIPTION
Update load-more-button docs to reflect changes from #174 
#174 requires that the `infinityModel` object be passed along with the `infinityLoad` action in order to work properly.
