### PR TITLE
Fix deprecation warning about didInsertElement modification

### DIFF
--- a/addon/components/infinity-loader.js
+++ b/addon/components/infinity-loader.js
@@ -14,7 +14,10 @@ const InfinityLoaderComponent = Ember.Component.extend({
   scrollable: null,
   triggerOffset: 0,
 
-  didInsertElement() {
+  didInsertElement(){
+    Ember.run.schedule('routerTransitions', this, ()  =>  this.setupElement());
+  },
+  setupElement() {
     this._super(...arguments);
     this._setupScrollable();
     this.set('guid', Ember.guidFor(this));

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -184,12 +184,12 @@ const RouteMixin = Mixin.create({
   _ensureCustomStoreCompatibility(options) {
     if (typeof options.store !== 'string') {
       throw new Ember.Error("Ember Infinity: Must pass custom data store as a string");
-    }
+    } 
 
     const store = this.get(options.store);
     if (!store[this.get('_storeFindMethod')]) {
       throw new Ember.Error("Ember Infinity: Custom data store must specify query method");
-    }
+    } 
   },
 
   /**
@@ -206,8 +206,6 @@ const RouteMixin = Mixin.create({
     if (emberDataVersionIs('lessThan', '1.13.0')) {
       this.set('_storeFindMethod', 'find');
     }
-
-    this._polyfillAssign();
 
     options = Object.assign({}, options);
 
@@ -442,40 +440,6 @@ const RouteMixin = Mixin.create({
 
     const totalPages = this.get('_totalPages');
     Ember.run.scheduleOnce('afterRender', this, 'infinityModelLoaded', { totalPages: totalPages });
-  },
-
-
-  /**
-   Fallback for IE Object.assign is not supported
-
-   @private
-   @method _polyfillAssign
-   */
-  _polyfillAssign() {
-    if (typeof Object.assign != 'function') {
-      Object.assign = function(target, varArgs) { // .length of function is 2
-        'use strict';
-        if (target == null) { // TypeError if undefined or null
-          throw new TypeError('Cannot convert undefined or null to object');
-        }
-
-        var to = Object(target);
-
-        for (var index = 1; index < arguments.length; index++) {
-          var nextSource = arguments[index];
-
-          if (nextSource != null) { // Skip over if undefined or null
-            for (var nextKey in nextSource) {
-              // Avoid bugs when hasOwnProperty is shadowed
-              if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
-                to[nextKey] = nextSource[nextKey];
-              }
-            }
-          }
-        }
-        return to;
-      };
-    }
   }
 });
 


### PR DESCRIPTION
This should fix the following deprecation warning for <= Ember 2.3.0.

>DEPRECATION: A property of <PROJECT@view:-outlet::ember1154> was modified inside the didInsertElement hook. You should never change properties on components, services or models during didInsertElement because it causes significant performance degradation. [deprecation id: ember-views.dispatching-modify-property]


