### PR TITLE
Adds support for using ember-infinity in a non-blocking model hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,3 +445,23 @@ template.hbs:
 
 {{load-more-button action='infinityLoad' infinityModel=model}}
 ```
+
+### Using ember-infinity with non-blocking model hooks
+
+Chances are you might want to render your templates without blocking the render for the initial model hook.
+Ember-infinity works with this but there are some gotchas.
+
+Ensure your model returns a proper Ember-Data request, or use an Ember [PromiseProxy](https://www.emberjs.com/api/ember/2.14/classes/Ember.PromiseProxyMixin) so that ember knows how to render your promise once it is resolved.
+Ensure you do not render the 'infinity-loader', if you are using it, until the initial model is loaded. If you are using the PromiseProxy above, you can use `{{#if .isFulfilled}}`. If you don't do this, the 'infinity-loader' might render on screen (because your infinity-list is not yet rendered), and immediately fire a request for the second page. You can also just push the 'infinity-loader' off screen with CSS to ensure you don't get this double request.
+
+Your model hook might look like:
+
+```js
+model() {
+  return {
+    things: this.infinityModel('post', {
+      modelPath: 'controller.model.things',
+    })
+  };
+}
+```

--- a/tests/acceptance/infinity-route-non-blocking-model-hook-test.js
+++ b/tests/acceptance/infinity-route-non-blocking-model-hook-test.js
@@ -1,0 +1,46 @@
+import { test } from 'qunit';
+import moduleForAcceptance from '../../tests/helpers/module-for-acceptance';
+import buildServer from '../helpers/fake-album-server';
+import assertDetails from '../helpers/assert-acceptance-details';
+
+let server;
+
+moduleForAcceptance('Acceptance: Infinity Route Non Blocking Model Hook', {
+  beforeEach() {
+    server = buildServer();
+  },
+  afterEach() {
+    server.shutdown();
+  }
+});
+
+function postList() {
+  return find('.test-list');
+}
+
+function scrollTo(offset) {
+  postList().scrollTop(offset);
+}
+
+test('it works when the model hook is non blocking', function(assert) {
+  visit('/non-blocking-model-hook');
+
+  andThen(() => {
+    assertDetails(assert, {
+      title: 'Non Blocking Model Hook',
+      listLength: 10,
+      reachedInfinity: false
+    });
+
+    scrollTo(100000);
+    triggerEvent('.test-list', 'scroll');
+  });
+
+  andThen(() => {
+    assertDetails(assert, {
+      title: 'Non Blocking Model Hook',
+      listLength: 20,
+      reachedInfinity: false
+    });
+  });
+});

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -16,6 +16,7 @@ Router.map(function() {
   this.route('posts', function() {
     this.route('show', { path: '/:post' });
   });
+  this.route('non-blocking-model-hook', { path: '/non-blocking-model-hook' });
 });
 
 export default Router;

--- a/tests/dummy/app/routes/non-blocking-model-hook.js
+++ b/tests/dummy/app/routes/non-blocking-model-hook.js
@@ -1,0 +1,57 @@
+import Ember from 'ember';
+import DS from 'ember-data';
+import InfinityRoute from 'ember-infinity/mixins/route';
+import Pretender from 'pretender';
+import faker from 'faker';
+import json from '../helpers/json';
+
+
+function generateFakeData(qty) {
+  var data = [];
+  for (var i = 0; i < qty; i++) {
+    data.push({id: i, name: faker.company.companyName()});
+  }
+  return data;
+}
+
+
+export default Ember.Route.extend(InfinityRoute, {
+  init: function () {
+    if (this._super.init) {
+      this._super.init.apply(this, arguments);
+    }
+    var fakeData = generateFakeData(104);
+    this.set('pretender', new Pretender());
+    this.get('pretender').get('/posts', request => {
+      var fd = fakeData;
+      var page = parseInt(request.queryParams.page, 10);
+      var per =  parseInt(request.queryParams.per_page, 10);
+      var payload = {
+        posts: fd.slice((page - 1) * per, Math.min((page) * per, fd.length)),
+        meta: {
+          total_pages: Math.ceil(fd.length/per)
+        }
+      };
+      return json(200, payload);
+
+    }, 500 /*ms*/);
+  },
+
+  tearDownPretender: Ember.observer('deactivate', function () {
+    this.set('pretender', undefined);
+  }),
+
+  model() {
+    // Returning POJO, important to not block the model hook
+    // PromiseArray becuase the pretender instance above is not returning at Ember-Data spec.
+    return {
+      things: DS.PromiseArray.create({
+        promise: this.infinityModel('post', {
+          modelPath: 'controller.model.things',
+          perPage: 10,
+          startingPage: 1
+        })
+      })
+    };
+  }
+});

--- a/tests/dummy/app/templates/non-blocking-model-hook.hbs
+++ b/tests/dummy/app/templates/non-blocking-model-hook.hbs
@@ -1,0 +1,16 @@
+<h2 id='posts-title'>Non Blocking Model Hook</h2>
+
+<ul class="test-list test-list-scrollable">
+  {{#each model.things as |things|}}
+    <li>{{things.name}}</li>
+  {{/each}}
+
+  {{#if model.things.isFulfilled}}
+    {{infinity-loader
+      infinityModel=model.things
+      scrollable=".test-list"
+      loadingText="loading"
+      loadedText="loaded"
+    }}
+  {{/if}}
+</ul>


### PR DESCRIPTION
Closes #232

Adds test support for non-blocking models.
Adds route to dummy app to demonstrate non-blocking model.
Adds notes to readme to help users figure this out.