### PR TITLE
README note: user action triggers infinity-loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,3 +448,17 @@ template.hbs:
 
 {{load-more-button action='infinityLoad' infinityModel=model}}
 ```
+
+### Delay start of infinite loading until user has indicated they would like to load more
+
+Infinite loading need not start automatically, it may be kickstarted from a user action. The infinity-loader component can be popped in and out, eg: each time a new search is entered, the component may be removed, and then put back in place at the user’s request.
+
+Example:
+
+```hbs
+{{#if hasClickedLoadMore}}
+  {{infinity-loader infinityModel=model triggerOffset=400}}
+{{else}}
+  <button {{action (toggle 'hasClickedLoadMore' this)}}>Load more</button>
+{{/if}}
+```

--- a/README.md
+++ b/README.md
@@ -451,9 +451,7 @@ template.hbs:
 
 ### Delay start of infinite loading until user has indicated they would like to load more
 
-Infinite loading need not start automatically, it may be kickstarted from a user action. The infinity-loader component can be popped in and out, eg: each time a new search is entered, the component may be removed, and then put back in place at the user’s request.
-
-Example:
+template.hbs:
 
 ```hbs
 {{#if hasClickedLoadMore}}


### PR DESCRIPTION
Added an example to the README of infinity-loader being triggered by a user action.

I had to do this in a project, and it may be obvious, but like most things Ember, I was tickled at how easily it was to make this happen.

In our project we stop automatic infinity loading each time the user changes their search parameters, and then ask them to initiate the infinite loading process again...