### PR TITLE
Infinity model will persist original request meta on itself

### DIFF
--- a/addon/lib/infinity-model.js
+++ b/addon/lib/infinity-model.js
@@ -77,6 +77,15 @@ export default ArrayProxy.extend({
   totalPagesParam: 'meta.total_pages',
 
   /**
+    Arbitrary meta copied over from
+    the HTTP response, to maintain the
+    default behavior of ember-data requests
+    @type objects
+    @default {}
+  */
+  meta: {},
+
+  /**
     @private
     @property _firstPageLoaded
     @type Boolean

--- a/addon/mixins/route.js
+++ b/addon/mixins/route.js
@@ -2,14 +2,14 @@ import Ember from 'ember';
 import InfinityModel from 'ember-infinity/lib/infinity-model';
 import InfinityPromiseArray from 'ember-infinity/lib/infinity-promise-array';
 import BoundParamsMixin from 'ember-infinity/mixins/bound-params';
-const { 
-  Mixin, 
-  computed, 
-  get, 
-  set, 
-  run, 
-  A, 
-  deprecate, 
+const {
+  Mixin,
+  computed,
+  get,
+  set,
+  run,
+  A,
+  deprecate,
   isEmpty,
   typeOf
 } = Ember;
@@ -107,7 +107,7 @@ const RouteMixin = Mixin.create({
     @method infinityModel
     @param {String} modelName The name of the model.
     @param {Object} options - optional - the perPage and startingPage to load from.
-    @param {Object} boundParamsOrInfinityModel - optional - 
+    @param {Object} boundParamsOrInfinityModel - optional -
       params on route to be looked up on every route request or
       instance of InfinityModel
     @return {Ember.RSVP.Promise}
@@ -119,9 +119,9 @@ const RouteMixin = Mixin.create({
       if (!(boundParamsOrInfinityModel instanceof InfinityModel)) {
         throw new Ember.Error("Ember Infinity: You must pass an Infinity Model instance as the third argument");
       }
-      ExtendedInfinityModel = boundParamsOrInfinityModel; 
+      ExtendedInfinityModel = boundParamsOrInfinityModel;
     } else if (typeOf(boundParamsOrInfinityModel) === "object") {
-      boundParams = boundParamsOrInfinityModel; 
+      boundParams = boundParamsOrInfinityModel;
     }
 
     if (modelName === undefined) {
@@ -301,6 +301,7 @@ const RouteMixin = Mixin.create({
   _doUpdate(queryObject, infinityModel) {
     const totalPages = queryObject.get(get(infinityModel, 'totalPagesParam'));
     set(infinityModel, '_totalPages', totalPages);
+    set(infinityModel, 'meta', get(queryObject, 'meta'));
     return infinityModel.pushObjects(queryObject.toArray());
   },
 

--- a/tests/unit/mixins/route-test.js
+++ b/tests/unit/mixins/route-test.js
@@ -76,7 +76,7 @@ test('it can not use infinityModel that is not an instance of InfinityModel', fu
   });
 
   let item = { id: 1, title: 'The Great Gatsby' };
-  let route = createRoute(['post', { store: 'simpleStore' }, ExtendedEmberObject], 
+  let route = createRoute(['post', { store: 'simpleStore' }, ExtendedEmberObject],
     { extra: 'param', simpleStore: createMockStore(EA([item])) });
 
   try {
@@ -253,6 +253,18 @@ test('it allows customizations of meta parsing params', function(assert) {
 
   assert.equal(model.get('totalPagesParam'), 'pagination.total', 'totalPagesParam');
   assert.equal(model.get('_totalPages'), 22, '_totalPages');
+});
+
+test('it copies arbitrary model hook meta from route request to the infinityModel', function(assert) {
+  let store = createMockStore(
+    EA([{id: 1, name: 'Walter White'}], { meta: { meaningOfLife: 42 }})
+  );
+
+  let route = createRoute(['item', {}],  { store });
+
+  let model = callModelHook(route);
+
+  assert.equal(model.get('meta.meaningOfLife'), 42, 'meta');
 });
 
 module('RouteMixin - reaching the end', {


### PR DESCRIPTION
In the app I work on, we rely on the `meta` property of ember-data requests quite often. 
I realized today that infinity-models lose this meta data as they are `toArray`'ed versions of the original request. 
In order to persist the requests meta, I believe all we need to do is simply copy it over in the `_doUpdate` method of the `inifintyModel` route mixin. 

It is a simple one liner:
```javascript
  _doUpdate(queryObject, infinityModel) {
    const totalPages = queryObject.get(get(infinityModel, 'totalPagesParam'));
    set(infinityModel, '_totalPages', totalPages);
    set(infinityModel, 'meta', get(queryObject, 'meta')); // BOOM
    return infinityModel.pushObjects(queryObject.toArray());
  },
```
This PR removes some hanging chad white-space as well. 

I was not actually sure how to write a test for this as I have not used ember-pretender very much. ( and am in a little rush to slam a feature) 

Please let me know if you can think of a more elegant way to persist this data. 
Cheers and Happy New Year. 🎆 🍾 
